### PR TITLE
Remove dead link to CoolStartupBro.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ Originally from [this HN post](https://news.ycombinator.com/item?id=7248460) whi
 * Cloudli.st - http://www.cloudli.st/apps/new
 * Cnet - https://upload.cnet.com/
 * Collaborizm - https://www.collaborizm.com
-* Cool Startup Bro - http://www.coolstartupbro.com/
 * Crazy About Startups - http://www.crazyaboutstartups.com/index.php/share-your-startup-form
 * CrozDesk - https://vendor.crozdesk.com/user/signup
 * Crunch Base - https://www.crunchbase.com/app/register


### PR DESCRIPTION
http://coolstartupbro.com redirects to a domain.com landing page.