### PR TITLE
Removes Ideahunt from list

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ Click a link to jump to the appropriate section. Both sections are organized alp
 * Gust - https://www.gust.com
 * Haro - https://www.helpareporter.com/sources/
 * Hackerspad - https://hackerspad.net/submit-software/
-* Idea Hunt - http://ideahunt.io/
 * Inc 42 - https://inc42.com/startup-submission/
 * Index.co - https://index.co/startup
 * Indie Hackers - https://www.indiehackers.com/


### PR DESCRIPTION
Ideahunt.io redirects to a different unrelated domain