### PR TITLE
Add Waitlio to websites list

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,114 +12,115 @@ Click a link to jump to the appropriate section. Both sections are organized alp
 
 # Reddit
 
-* /r/AlphaandBetausers - https://www.reddit.com/r/alphaandbetausers/
-* /r/buildinpublic - https://www.reddit.com/r/buildinpublic/
-* /r/Coupons - https://www.reddit.com/r/coupons/
-* /r/Design_Critiques - https://www.reddit.com/r/design_critiques/
-* /r/Entrepreneur - https://reddit.com/r/entrepreneur
-* /r/EntrepreneurRideAlong - https://www.reddit.com/r/EntrepreneurRideAlong/
-* /r/IMadeThis - https://reddit.com/r/imadethis
-* /r/IndieBiz - https://www.reddit.com/r/indiebiz/
-* /r/indiehackers - https://www.reddit.com/r/indiehackers/
-* /r/LadyBusiness - https://www.reddit.com/r/ladybusiness/
-* /r/microsaas - https://www.reddit.com/r/microsaas/
-* /r/plugyourproduct - https://www.reddit.com/r/plugyourproduct/
-* /r/RoastMyStartup - https://www.reddit.com/r/roastmystartup
-* /r/SaaS - https://www.reddit.com/r/SaaS/
-* /r/shamelessplug - https://www.reddit.com/r/shamelessplug/
-* /r/SideProject - https://reddit.com/r/sideproject
-* /r/SmallBusiness - https://www.reddit.com/r/smallbusiness/
-* /r/Startups - https://reddit.com/r/startups
-* /r/thesidehustle - https://www.reddit.com/r/thesidehustle/
+- /r/AlphaandBetausers - https://www.reddit.com/r/alphaandbetausers/
+- /r/buildinpublic - https://www.reddit.com/r/buildinpublic/
+- /r/Coupons - https://www.reddit.com/r/coupons/
+- /r/Design_Critiques - https://www.reddit.com/r/design_critiques/
+- /r/Entrepreneur - https://reddit.com/r/entrepreneur
+- /r/EntrepreneurRideAlong - https://www.reddit.com/r/EntrepreneurRideAlong/
+- /r/IMadeThis - https://reddit.com/r/imadethis
+- /r/IndieBiz - https://www.reddit.com/r/indiebiz/
+- /r/indiehackers - https://www.reddit.com/r/indiehackers/
+- /r/LadyBusiness - https://www.reddit.com/r/ladybusiness/
+- /r/microsaas - https://www.reddit.com/r/microsaas/
+- /r/plugyourproduct - https://www.reddit.com/r/plugyourproduct/
+- /r/RoastMyStartup - https://www.reddit.com/r/roastmystartup
+- /r/SaaS - https://www.reddit.com/r/SaaS/
+- /r/shamelessplug - https://www.reddit.com/r/shamelessplug/
+- /r/SideProject - https://reddit.com/r/sideproject
+- /r/SmallBusiness - https://www.reddit.com/r/smallbusiness/
+- /r/Startups - https://reddit.com/r/startups
+- /r/thesidehustle - https://www.reddit.com/r/thesidehustle/
 
 [Back to Top](#places-to-post-your-startup)
 
 # Websites
 
-* 10words - https://10words.io
-* AI Collection - https://www.thataicollection.com/
-* All My Faves - https://www.allmyfaves.com/
-* All Startups - https://www.allstartups.info/Startups/Submit
-* All Top Startups - https://alltopstartups.com/submit-startup/
-* Alternative To - https://alternativeto.net/
-* Alternative.me - https://alternative.me/
-* AngelList - https://angel.co/
-* App Rater - https://apprater.net/add/
-* Appoid - https://appiod.com/submit-app-for-review/
-* appPicker - https://www.apppicker.com/
-* Apps Listo - https://appslisto.com/submit-your-app/
-* Apps Mamma - https://appsmamma.com/submit-your-app/
-* AppsThunder - https://appsthunder.com/submit-your-app/
-* Appvita - https://www.appvita.com/
-* Arctic Startup - https://arcticstartup.com/
-* Awesome Indie - https://awesomeindie.com
-* Beta Bound - https://www.betabound.com/announce/
-* Beta Testing - https://betatesting.com/beta-testing
-* BuiltInChicago - https://www.builtinchicago.org/send-us-tip
-* Capterra - https://www.capterra.com/vendors/sign-up
-* Collaborizm - https://www.collaborizm.com
-* CrozDesk - https://vendor.crozdesk.com/user/signup
-* Crunch Base - https://www.crunchbase.com/#/home/index
-* Discover Cloud - https://www.discovercloud.com/become-a-vendor
-* eBool - https://www.ebool.com/submit
-* F6S - https://www.f6s.com/
-* Fiddy - https://fiddy.co
-* G2 Crowd - https://www.g2crowd.com/products/new
-* Geek Wire - https://geekwire.com/startup-list/
-* Get App - https://getapp.com/
-* Getworm - https://getworm.com/submit-startup
-* Gust - https://www.gust.com
-* Inc 42 - https://inc42.com/startup-submission/
-* Indie Hackers - https://www.indiehackers.com/
-* Killer Startups - https://killerstartups.com/submit-startup/
-* Land-book - https://land-book.com/guidelines
-* Launched - https://launched.io/SubmitStartup
-* LaunchIgniter - https://launchigniter.com/submit
-* Launching Next - https://www.launchingnext.com/submit/
-* Loop - https://app.loopinput.com/
-* MakeUseOf - https://www.makeuseof.com/about/
-* Micro SaaS Examples - https://www.microsaasexamples.com/
-* Netted - https://www.netted.net/contact-us/
-* Next Big What - https://nextbigwhat.com/
-* PitchWall - https://pitchwall.co/product/submit
-* Postmake - https://postmake.io/submit
-* PreApps - https://www.preapps.com/
-* Product Hunt - https://www.producthunt.com/
-* Project Hatch - https://www.projecthatch.co/your-story/
-* SaaSHub - https://www.saashub.com/
-* SaasRow - https://saasrow.com/
-* Saijo's Tools List - https://saijogeorge.com/best-marketing-tools/
-* Show HN - https://news.ycombinator.com/showhn.html
-* Side Projectors - https://www.sideprojectors.com
-* Simple Lister - https://simplelister.com/
-* SimilarSiteSearch - https://www.similarsitesearch.com/tips.html
-* Slant - https://www.slant.co/
-* SnapMunk - https://www.snapmunk.com/submit-your-startup/
-* Software Advice - https://softwareadvice-markets.questionpro.com/
-* Stack Share - https://stackshare.io/
-* Starter Story - https://starterstory.com/
-* Startup 88 - https://startup88.com/
-* Startup Base - https://startupbase.io/submit
-* Startup Beat - https://startupbeat.com/startup-beat-featured-startup-pitch-guidelines/
-* Startup Benchmarks - https://www.startupbenchmarks.com/
-* Startup Buffer - https://startupbuffer.com
-* Startup Inspire - https://www.startupinspire.com/submit
-* Startup Ranking - https://www.startupranking.com/
-* Startup Stash - https://startupstash.com/
-* Startup Tabs - https://startuptabs.com/
-* Startup Tracker - https://startuptracker.io/
-* StartupBlink - https://www.startupblink.com/
-* Startups Gallery - https://startups.gallery/
-* State of Tech - https://stateoftech.net/advertise?submit-an-app-for-review
-* Tabscape - https://www.tapscape.com/
-* Tech Map - https://thetechmap.com/
-* Tech Pluto - https://www.techpluto.com/submit-a-startup/
-* Tiny Launch - https://www.tinylaunch.com
-* The Changelog - https://github.com/thechangelog/ping
-* Vator - https://www.vator.tv/
-* Web App Rater - https://webapprater.com/submit-your-web-application-for-review-html
-* Website Hunt - https://www.websitehunt.co
-* Ycombinator - https://news.ycombinator.com/
+- 10words - https://10words.io
+- AI Collection - https://www.thataicollection.com/
+- All My Faves - https://www.allmyfaves.com/
+- All Startups - https://www.allstartups.info/Startups/Submit
+- All Top Startups - https://alltopstartups.com/submit-startup/
+- Alternative To - https://alternativeto.net/
+- Alternative.me - https://alternative.me/
+- AngelList - https://angel.co/
+- App Rater - https://apprater.net/add/
+- Appoid - https://appiod.com/submit-app-for-review/
+- appPicker - https://www.apppicker.com/
+- Apps Listo - https://appslisto.com/submit-your-app/
+- Apps Mamma - https://appsmamma.com/submit-your-app/
+- AppsThunder - https://appsthunder.com/submit-your-app/
+- Appvita - https://www.appvita.com/
+- Arctic Startup - https://arcticstartup.com/
+- Awesome Indie - https://awesomeindie.com
+- Beta Bound - https://www.betabound.com/announce/
+- Beta Testing - https://betatesting.com/beta-testing
+- BuiltInChicago - https://www.builtinchicago.org/send-us-tip
+- Capterra - https://www.capterra.com/vendors/sign-up
+- Collaborizm - https://www.collaborizm.com
+- CrozDesk - https://vendor.crozdesk.com/user/signup
+- Crunch Base - https://www.crunchbase.com/#/home/index
+- Discover Cloud - https://www.discovercloud.com/become-a-vendor
+- eBool - https://www.ebool.com/submit
+- F6S - https://www.f6s.com/
+- Fiddy - https://fiddy.co
+- G2 Crowd - https://www.g2crowd.com/products/new
+- Geek Wire - https://geekwire.com/startup-list/
+- Get App - https://getapp.com/
+- Getworm - https://getworm.com/submit-startup
+- Gust - https://www.gust.com
+- Inc 42 - https://inc42.com/startup-submission/
+- Indie Hackers - https://www.indiehackers.com/
+- Killer Startups - https://killerstartups.com/submit-startup/
+- Land-book - https://land-book.com/guidelines
+- Launched - https://launched.io/SubmitStartup
+- LaunchIgniter - https://launchigniter.com/submit
+- Launching Next - https://www.launchingnext.com/submit/
+- Loop - https://app.loopinput.com/
+- MakeUseOf - https://www.makeuseof.com/about/
+- Micro SaaS Examples - https://www.microsaasexamples.com/
+- Netted - https://www.netted.net/contact-us/
+- Next Big What - https://nextbigwhat.com/
+- PitchWall - https://pitchwall.co/product/submit
+- Postmake - https://postmake.io/submit
+- PreApps - https://www.preapps.com/
+- Product Hunt - https://www.producthunt.com/
+- Project Hatch - https://www.projecthatch.co/your-story/
+- SaaSHub - https://www.saashub.com/
+- SaasRow - https://saasrow.com/
+- Saijo's Tools List - https://saijogeorge.com/best-marketing-tools/
+- Show HN - https://news.ycombinator.com/showhn.html
+- Side Projectors - https://www.sideprojectors.com
+- Simple Lister - https://simplelister.com/
+- SimilarSiteSearch - https://www.similarsitesearch.com/tips.html
+- Slant - https://www.slant.co/
+- SnapMunk - https://www.snapmunk.com/submit-your-startup/
+- Software Advice - https://softwareadvice-markets.questionpro.com/
+- Stack Share - https://stackshare.io/
+- Starter Story - https://starterstory.com/
+- Startup 88 - https://startup88.com/
+- Startup Base - https://startupbase.io/submit
+- Startup Beat - https://startupbeat.com/startup-beat-featured-startup-pitch-guidelines/
+- Startup Benchmarks - https://www.startupbenchmarks.com/
+- Startup Buffer - https://startupbuffer.com
+- Startup Inspire - https://www.startupinspire.com/submit
+- Startup Ranking - https://www.startupranking.com/
+- Startup Stash - https://startupstash.com/
+- Startup Tabs - https://startuptabs.com/
+- Startup Tracker - https://startuptracker.io/
+- StartupBlink - https://www.startupblink.com/
+- Startups Gallery - https://startups.gallery/
+- State of Tech - https://stateoftech.net/advertise?submit-an-app-for-review
+- Tabscape - https://www.tapscape.com/
+- Tech Map - https://thetechmap.com/
+- Tech Pluto - https://www.techpluto.com/submit-a-startup/
+- Tiny Launch - https://www.tinylaunch.com
+- The Changelog - https://github.com/thechangelog/ping
+- Vator - https://www.vator.tv/
+- Waitlio - https://waitlio.com/
+- Web App Rater - https://webapprater.com/submit-your-web-application-for-review-html
+- Website Hunt - https://www.websitehunt.co
+- Ycombinator - https://news.ycombinator.com/
 
 [Back to Top](#places-to-post-your-startup)
 


### PR DESCRIPTION
## Summary

- Adds [Waitlio](https://waitlio.com/) to the Websites section (alphabetical order)

Waitlio is free waitlist software for product launches — lets you create branded waitlist pages, collect and verify email subscribers, and manage your pre-launch audience. Free plan included.