### PR TITLE
Add daily.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Click a link to jump to the appropriate section. Both sections are organized alp
 * Collaborizm - https://www.collaborizm.com
 * CrozDesk - https://vendor.crozdesk.com/user/signup
 * Crunch Base - https://www.crunchbase.com/#/home/index
+* daily.dev - https://daily.dev/
 * Discover Cloud - https://www.discovercloud.com/become-a-vendor
 * eBool - https://www.ebool.com/submit
 * F6S - https://www.f6s.com/


### PR DESCRIPTION
[daily.dev](https://daily.dev/) is a developer content platform with 1M+ registered developers. Companies can create a Source page to share their blog content directly in the developer feed, reaching an engaged technical audience for free.